### PR TITLE
📝doc where to get an API key from

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,17 @@
 ## Overview
 This is a Javascript implementation of the various APIs provided by the Stock services.
 
+## Before You Begin
+Get a Stock API Key by [creating a Creative Cloud Adobe Stock integration on console.adobe.io](https://console.adobe.io/integrations/new).
+
+### Install Dependencies
+- `yarn install`
+
+## Build
+- `yarn run build`
+
+Creates the JavaScript library file under the `dist/` directory.
+
 ## Usage
 ### AdobeStock
 #### Instantiation
@@ -707,15 +718,9 @@ const PURCHASE_STATE_PARAMS = {
 };
 ```
 
-## Install Dependencies
-- `yarn install`
-
 ## Running the Test Suite
 - `yarn test` ( eslint, mocha )
 This also generates code coverage report using karma test runner.
 
 ### Linting
 - `yarn run lint`
-
-## Build
-- `yarn run build`


### PR DESCRIPTION
## Overview

Describes where to get an API key from, near the top of the README (consumers of this library will need one to use it). Also small tweaks to ordering of instructions based on first-run need (installation, registration instructions first, then build, test/lint last).